### PR TITLE
doubleではなくてVCRにしてみる

### DIFF
--- a/lib/slack_goodies/connection.rb
+++ b/lib/slack_goodies/connection.rb
@@ -8,7 +8,7 @@ module SlackGoodies
         raise ApiKeyPermissionError.exception(chk["error"])
       end
 =end
-      @slack = nil 
+      @slack = slack_client
       @channels = nil
     end
     def slack_client
@@ -21,9 +21,8 @@ module SlackGoodies
       @slack.auth_test
     end
     def channel_list
-      slack = slack_client
       return @channels if !@channels.nil?
-      @channels = slack.channels_list
+      @channels = @slack.channels_list
     end
     def users_list 
       return @users if !@users.nil?

--- a/slack_goodies.gemspec
+++ b/slack_goodies.gemspec
@@ -27,4 +27,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency "slack-ruby-client"
   spec.add_development_dependency "cucumber"
   spec.add_development_dependency "rspec", "~> 3.2"
+  spec.add_development_dependency "vcr"
+  spec.add_development_dependency "webmock"
 end

--- a/spec/slack_goodies_spec.rb
+++ b/spec/slack_goodies_spec.rb
@@ -7,11 +7,10 @@ VCR.configure do |config|
 end
 describe SlackGoodies::Connection do
    it "public channelの一覧が取得出来る" do
-      slack_api_mock = double("Slack API")
-      allow(slack_api_mock).to receive(:channels_list)
       connection = SlackGoodies::Connection.new
-      allow(connection).to receive(:slack_client).and_return(slack_api_mock)
-      expect { connection.channel_list }.not_to raise_error
+      VCR.use_cassette("channels_list") do
+        expect { connection.channel_list }.not_to raise_error
+      end
    end
 end
 

--- a/spec/slack_goodies_spec.rb
+++ b/spec/slack_goodies_spec.rb
@@ -1,4 +1,10 @@
 require 'slack_goodies'
+require 'vcr'
+require 'webmock/rspec'
+VCR.configure do |config|
+  config.cassette_library_dir = "spec/fixtures/vcr_cassettes"
+  config.hook_into :webmock
+end
 describe SlackGoodies::Connection do
    it "public channelの一覧が取得出来る" do
       slack_api_mock = double("Slack API")


### PR DESCRIPTION
#2 でdoubleでmockを作成して、本来APIが返す値をいじって戻すメソッドをmockに置き換えて単純に何もしないメソッドにしただけなので今後何をテストすればよいのだ…と今後の方向性がわからない感じになってしまったけど、
このgemのテストはVCRでAPIの返す値をファイルに保存してそれを読み込んでテストするようにした方がよさそうという助言をもらったのでVCRにしてみる

VCRはhttpの通信の記録を初回アクセス時にファイルに保存して、2回目以降はファイルから値を取り出してくれる便利gem

VCR https://github.com/vcr/vcr
